### PR TITLE
resume_session: Added a feature to delete the session

### DIFF
--- a/turbogpt/turbogpt.py
+++ b/turbogpt/turbogpt.py
@@ -79,6 +79,12 @@ class TurboGpt:
 
         parent_id = res.json()["current_node"]
         return {"conversation_id": chat_id, "message": {"id": parent_id}}
+        
+    def delete_session(self, chat_id):
+        res = self.session.patch(
+            "https://chat.openai.com/backend-api/conversation/" + chat_id,
+            json={"is_visible": "false"}
+        )
 
     def send_message(self, message, old_question):
         res = self.session.post(


### PR DESCRIPTION
**Summary:**

This pull request adds a new method called delete_session to the TurboGpt class. This method allows a user to delete a chat session by making a PATCH request to the chat.openai.com backend API, which sets the is_visible flag of the specified chat session to false.

**Motivation and Context:**

Previously, the TurboGpt class didn't provide a way to delete or hide a chat session. This functionality can be useful in various scenarios, such as when a user has finished a chat session and wants to clean up, or when a chat session contains sensitive data that should be hidden.

**Code Changes:**

A single method delete_session was added to the TurboGpt class:

```
def delete_session(self, chat_id):
    res = self.session.patch(
        "https://chat.openai.com/backend-api/conversation/" + chat_id,
        json={"is_visible": "false"}
    )
```
This method takes a chat_id as an argument, makes a PATCH request to the chat.openai.com backend API, and sets the is_visible flag of the corresponding chat session to false.

**Testing:**

No new tests were added in this pull request. The functionality of the delete_session method should be verified manually by creating a chat session, deleting it using this method, and checking that it is no longer visible.

**Impact:**

This change is expected to have minimal impact on the existing system as it's an addition of a new feature. No other parts of the system use or rely on this new method, and no existing functionality is modified by this change.

